### PR TITLE
fix x-y scaling of xy_verts array

### DIFF
--- a/opppy/plot_dump_dictionary.py
+++ b/opppy/plot_dump_dictionary.py
@@ -387,6 +387,7 @@ class plot_2d_dump_dictionary():
 
         if args.xy_verts_name is not None:
             xy_verts = dictionary[args.xy_verts_name]
+            xy_verts = [ [[xy[0]*args.scale_x,xy[1]*args.scale_y] for xy in verts] for verts in xy_verts]
             fig, ax = PyPloter.subplots()
             xmin = None
             xmax = None


### PR DESCRIPTION
Previously the x and y scaling was not correctly applied when plotting with xy_verts. This fixes it so you can have arbitrary x or y scaling even when doing patch based plotting. 