### PR TITLE
Fix dump name append when dir is included in file name

### DIFF
--- a/opppy/dump_utils.py
+++ b/opppy/dump_utils.py
@@ -498,7 +498,7 @@ def append_dumps(data, dump_files, opppy_parser, key_words=None):
     count = 0
     for dump in dump_files:
       # append new dictionary data to the pickle file
-      data[dump.split('/')[0]] = opppy_parser.build_data_dictionary(dump,key_words)
+      data[dump.split('/')[-1]] = opppy_parser.build_data_dictionary(dump,key_words)
       count += 1
       progress(count,total, 'of dump files read')
 


### PR DESCRIPTION
The append dump name was broken because we where indexing the first dir in the file path rather than the final name in the file path. This fixes the index so multiple dump files can be append in the same dir.