### PR TITLE
Cleanup of syntax warnings

### DIFF
--- a/opppy/dump_utils.py
+++ b/opppy/dump_utils.py
@@ -331,7 +331,7 @@ def extract_series_point(data_list,series_key,value_key,dim_keys,point_values,me
     T = []
     Y = []
     for data in data_list:
-        if dim is 1:
+        if dim == 1:
             if len(data[series_key]) == 1:
                 T.append(data[series_key][0])
             else:
@@ -340,7 +340,7 @@ def extract_series_point(data_list,series_key,value_key,dim_keys,point_values,me
                 Y.append(data[value_key][0])
             else:
                 Y.append(point_value_1d(data, dim_keys[0], value_key, point_values[0], method)[0])
-        elif dim is 2:
+        elif dim == 2:
             if len(data[series_key]) == 1:
                 T.append(data[series_key][0])
             else:
@@ -397,10 +397,10 @@ def extract_series_line(data_list,series_key,value_key,dim_keys,point0_values,po
             print("Error: series_key dictionary item must return a single value (i.e. cycle or time)")
             sys.exit(0)
         my_grid = {}
-        if dim is 1:
+        if dim == 1:
             my_grid['distance'], my_grid[value_key] = data2line1d(data, dim_keys[0], value_key, point0_values[0], point1_values[0], npts, method)
             grid.append(my_grid)
-        elif dim is 2:
+        elif dim == 2:
             my_grid['distance'], my_grid[value_key]  = data2line2d(data, dim_keys[0], dim_keys[1], value_key, point0_values[0], point0_values[1], point1_values[0], point1_values[1], npts, method)
             grid.append(my_grid)
         else:
@@ -428,7 +428,7 @@ def extract_series_2d(data_list, series_key, value_key, dim_keys, npts=500, meth
             [x1, y1, x2, y2]
     '''
     dim = len(dim_keys)
-    if dim is not 2:
+    if dim != 2:
         print("ERROR: 2D series can only be used with 2 dimensional data")
         sys.exit(0)
     T = []
@@ -439,7 +439,7 @@ def extract_series_2d(data_list, series_key, value_key, dim_keys, npts=500, meth
         else:
             print("Error: series_key dictionary item must return a single value (i.e. cycle or time)")
             sys.exit(0)
-        if len(box) is 0:
+        if len(box) == 0:
             grid.append(data2grid(data, dim_keys[0], dim_keys[1], value_key, npts, method))
         else:
             grid.append(data2gridbox(data, dim_keys[0], dim_keys[1], value_key, box[0], box[1], box[2], box[3],npts,method))
@@ -464,7 +464,7 @@ def extract_series_2d_slice(data_list,series_key,value_key,dim_keys, slice_value
         method - Method for interpolation
     '''
     dim = len(dim_keys)
-    if dim is not 3:
+    if dim != 3:
         print("ERROR: 3d slice can only be used with 3 dimensional data")
         sys.exit(0)
     T = []

--- a/opppy/interactive_utils.py
+++ b/opppy/interactive_utils.py
@@ -804,12 +804,12 @@ class interactive_dump_parser:
             tracer_t = {}
             tracer_grid = {}
             if args.z_slice_location is not None:
-                if len(args.dimension_keys) is not 3:
+                if len(args.dimension_keys) != 3:
                     print('Error: z_slice_location specified so length of dimension_keys must be 3')
                     sys.exit(0)
                 tracer_t, tracer_grid = extract_series_2d_slice(dictionary_list, args.series_key, args.data_name, args.dimension_keys, args.z_slice_location, args.number_of_points, args.interpolation_method) 
             else:
-                if len(args.dimension_keys) is not 2:
+                if len(args.dimension_keys) != 2:
                     print('Error: z_slice_location specified is not specified so length of dimension_keys must be 2')
                 tracer_t, tracer_grid = extract_series_2d(dictionary_list, args.series_key, args.data_name, args.dimension_keys, args.number_of_points, args.interpolation_method) 
             series_data = series_pair(tracer_t, tracer_grid)
@@ -822,12 +822,12 @@ class interactive_dump_parser:
             tracer_t = {}
             tracer_grid = {}
             if args.z_slice_location is not None:
-                if len(args.dimension_keys) is not 3:
+                if len(args.dimension_keys) != 3:
                     print('Error: z_slice_location specified so length of dimension_keys must be 3')
                     sys.exit(0)
                 tracer_t, tracer_grid = extract_series_2d_slice(dictionary_list, args.series_key, args.data_name, args.dimension_keys, args.z_slice_location, args.number_of_points, args.interpolation_method) 
             else:
-                if len(args.dimension_keys) is not 2:
+                if len(args.dimension_keys) != 2:
                     print('Error: z_slice_location specified is not specified so length of dimension_keys must be 2')
                 tracer_t, tracer_grid = extract_series_2d(dictionary_list, args.series_key, args.data_name, args.dimension_keys, args.number_of_points, args.interpolation_method) 
             series_data = series_pair(tracer_t, tracer_grid)
@@ -836,12 +836,12 @@ class interactive_dump_parser:
             tracer_t = {}
             tracer_grid = {}
             if args.z_slice_location is not None:
-                if len(args.dimension_keys) is not 3:
+                if len(args.dimension_keys) != 3:
                     print('Error: z_slice_location specified so length of dimension_keys must be 3')
                     sys.exit(0)
                 tracer_t, tracer_grid = extract_series_2d_slice(dictionary_list, args.series_key, args.data_name, args.dimension_keys, args.z_slice_location, args.number_of_points, args.interpolation_method) 
             else:
-                if len(args.dimension_keys) is not 2:
+                if len(args.dimension_keys) != 2:
                     print('Error: z_slice_location specified is not specified so length of dimension_keys must be 2')
                 tracer_t, tracer_grid = extract_series_2d(dictionary_list, args.series_key, args.data_name, args.dimension_keys, args.number_of_points, args.interpolation_method) 
             series_data = series_pair(tracer_t, tracer_grid)

--- a/opppy/output.py
+++ b/opppy/output.py
@@ -259,7 +259,7 @@ def get_output_lines(filename,opening_string,closing_string, file_end_string=Non
           reading_cycle = True
       elif reading_cycle and closing_string in str(line):
           # catch the special exception when the line is a return character
-          if closing_string == '\n' and len(line) is not 1:
+          if closing_string == '\n' and len(line) != 1:
               temp_lines += line
               continue
           reading_cycle = False


### PR DESCRIPTION
Cleanup of syntax warnings caused by using "is" and "is not" with integers (literals), as opposed to "==" and "!=".
I was getting warnings under python 3.8.3, such as

`/Users/lowrie/Share/TWS/tws-xrage/OPPPY/opppy/dump_utils.py:334: SyntaxWarning: "is" with a literal. Did you mean "=="?
  if dim is 1:`