### PR TITLE
MAINT, BUG: parser doesn't exist

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8]
+        python-version: ["3.9", "3.10", "3.11"]
 
     steps:
     - uses: actions/checkout@v2

--- a/opppy/plotting_help.py
+++ b/opppy/plotting_help.py
@@ -30,7 +30,7 @@ import math
 import numpy as np
 import matplotlib.pyplot as PyPloter
 import re
-import parser
+import ast
 
 
 ####################################################
@@ -230,7 +230,7 @@ def get_value(y_value_name, names, data):
             sys.exit()
     # Convert the function string to a function
     # print y_value_name, function_string
-    function = parser.expr(function_string).compile()
+    function = ast.parse(function_string).compile()
     # return the function evaluation
     return eval(function)
 


### PR DESCRIPTION
* the `parser` module was removed in Python `3.10`, so we can't use that anymore; `ast` has been encouraged as the preferred choice since ~Python 2.7 (see: https://stackoverflow.com/a/73328678/2942522)

* I've attempted to replace the old usage with a modern equivalent; the testsuite passes with this change locally, though that doesn't guarantee this particular functionality still works as expected; either way, `OPPPY` is unusable in the current state with Python versions at or above `3.10`