### PR TITLE
MAINT, TST: remove usage of test.support

### DIFF
--- a/tests/test_dict_plotting.py
+++ b/tests/test_dict_plotting.py
@@ -14,7 +14,6 @@ import os
 dir_path = os.path.dirname(os.path.realpath(__file__))+"/"
 
 import unittest
-from test import support
 import shlex
 
 from opppy.output import *
@@ -55,13 +54,3 @@ class test_dict_plotting(unittest.TestCase):
 
     # generate a plot given my plotting arguments, dictionary, and data name
     ploter.plot_dict(args, [data], ["my_test_dict"])
-
-
-    
-
-
-def test_main():
-  support.run_unittest(test_dict_plotting)
-
-if __name__ == '__main__':
-  test_main()

--- a/tests/test_dump_ploter.py
+++ b/tests/test_dump_ploter.py
@@ -279,11 +279,3 @@ class test_opppy_dump_utils(unittest.TestCase):
         print("Is data available", contour_series_ploter.is_data_available(args, series_data))
         # generate a plot given my plotting arguments, dictionary, and data name
         contour_series_ploter.plot_2d_series(args, series_data)
-
-
- 
-def test_main():
-  support.run_unittest(test_opppy_dump_utils)
-
-if __name__ == '__main__':
-  test_main()

--- a/tests/test_dump_utils.py
+++ b/tests/test_dump_utils.py
@@ -16,7 +16,6 @@ dir_path = os.path.dirname(os.path.realpath(__file__))+"/"
 
 from opppy.dump_utils import *
 import unittest
-from test import support
 
 class test_opppy_dump_utils(unittest.TestCase):
     def test_dump_parser(self):
@@ -226,12 +225,3 @@ class test_opppy_dump_utils(unittest.TestCase):
         print(tracer_t, tracer_grid)
         tracer_t, tracer_grid = extract_series_line(data,'time',"temperature",['x','y','z'], [5.0, 1.0, 1.2],  [5.0, 2.0, 1.75], npts=5  )
         print(tracer_t, tracer_grid)
-        
-
-
- 
-def test_main():
-  support.run_unittest(test_opppy_dump_utils)
-
-if __name__ == '__main__':
-  test_main()

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -16,7 +16,6 @@ dir_path = os.path.dirname(os.path.realpath(__file__))+"/"
 
 import os
 import unittest
-from test import support
 import shlex
 
 class test_interactive_utils(unittest.TestCase):
@@ -139,12 +138,3 @@ class test_interactive_utils(unittest.TestCase):
         os.system("python my_interactive_parser.py tally plot -pf interactive_tally.p -sk time -sv 5.0 -dn cool_counts -x bins -xlab 'bin [#]'  -y even_counts  -ylab 'Counts [#]'")
         # test scaling and log axis
         os.system("python my_interactive_parser.py tally plot -tf "+dir_path+"example_tally*.txt -tf "+dir_path+"example_tally*.txt -sk cycle -dn cool_counts -x bins -xlab 'bin [#]'  -y odd_counts  -ylab 'Counts  [#]' -lx -ly -sx 10 -sx 1e-3 -sy 10 -sy 1e-3 -xl 0.00001 1000 -yl 0.00001 10000")
-
-
- 
-
-def test_main():
-  support.run_unittest(test_interactive_utils)
-
-if __name__ == '__main__':
-  unittest.main()

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -14,7 +14,6 @@ import os
 dir_path = os.path.dirname(os.path.realpath(__file__))+"/"
 
 import unittest
-from test import support
 
 from opppy.output import *
 
@@ -112,10 +111,3 @@ class test_opppy_outputs(unittest.TestCase):
     append_output_dictionary(data2, output_files, opppy_parser)
 
     print(data2)
-  
-  
-def test_main():
-  support.run_unittest(test_opppy_outputs)
-
-if __name__ == '__main__':
-  test_main()

--- a/tests/test_tally.py
+++ b/tests/test_tally.py
@@ -14,7 +14,6 @@ import os
 dir_path = os.path.dirname(os.path.realpath(__file__))+"/"
 
 import unittest
-from test import support
 
 from opppy.output import *
 from opppy.tally import *
@@ -87,10 +86,3 @@ class test_opppy_tally(unittest.TestCase):
     append_tally_dictionary(data2, tally_files, opppy_parser)
 
     print(data2)
-  
-  
-def test_main():
-  support.run_unittest(test_opppy_tally)
-
-if __name__ == '__main__':
-  test_main()

--- a/tests/test_tally_plotting.py
+++ b/tests/test_tally_plotting.py
@@ -14,7 +14,6 @@ import os
 dir_path = os.path.dirname(os.path.realpath(__file__))+"/"
 
 import unittest
-from test import support
 import shlex
 
 from opppy.tally import *
@@ -60,13 +59,3 @@ class test_dict_plotting(unittest.TestCase):
 
     # generate a plot given my plotting arguments, dictionary, and data name
     ploter.plot_dict(args, [data['tally_cycle_data'][index],data['tally_cycle_data'][index+1]], ["my_test_dict t ="+str(data['time'][index]), "my_test_dict t ="+str(data['time'][index+1])])
-
-
-    
-
-
-def test_main():
-  support.run_unittest(test_dict_plotting)
-
-if __name__ == '__main__':
-  test_main()


### PR DESCRIPTION
* related to https://github.com/lanl/OPPPY/pull/32#issuecomment-1879027998 cc @clevelam 

* the `test` package in CPython is intended for internal use by the CPython development team only, and is subject to API changes without prior deprecation, as noted here: https://docs.python.org/3.11/library/test.html

* `test.support.run_unittest` is not available in Python `3.11.7`, but is available in some other versions of `3.11.x` and `3.12.x`; clearly depending on that is not really sane, so let's just remove the usage--this allows the full test suite to pass for me locally with `3.11.7`

* I don't think there was any good reason to keep those `test_main()` style blocks anyway--perhaps you can encourage developers to use `pytest path/to/test_module.py`, which will do the same thing (most/all OSS packages would suggest that at this point I think); if you have folks who were running the tests with `python path/to/test_module.py` they'd need to swap to using `pytest` for the incantation, but maybe that's something you can live with?