### PR TITLE
Limit the number of parsing threads

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,6 +26,9 @@ jobs:
 ##         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 ##         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
 ##         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test
+    - name: Threaded Test
       run: |
         python -m pytest --cov-report term-missing --cov=opppy  tests/
+    - name: Serial Test
+      run: |
+        OPPPY_USE_THREADS=false python -m pytest --cov-report term-missing --cov=opppy  tests/

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -26,11 +26,6 @@ jobs:
 ##         flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
 ##         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
 ##         flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Threaded Test
+    - name: Testing
       run: |
         python -m pytest --cov-report term-missing --cov=opppy  tests/
-    - name: Serial Test
-      run: |
-        python -m pytest --cov-report term-missing --cov=opppy  tests/
-      env: 
-          OPPPY_USE_THREADS: false

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -31,4 +31,6 @@ jobs:
         python -m pytest --cov-report term-missing --cov=opppy  tests/
     - name: Serial Test
       run: |
-        OPPPY_USE_THREADS=false python -m pytest --cov-report term-missing --cov=opppy  tests/
+        python -m pytest --cov-report term-missing --cov=opppy  tests/
+      env: 
+        OPPPY_USE_THREADS=false

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,4 +33,4 @@ jobs:
       run: |
         python -m pytest --cov-report term-missing --cov=opppy  tests/
       env: 
-        OPPPY_USE_THREADS=false
+          OPPPY_USE_THREADS: false

--- a/opppy/dump_utils.py
+++ b/opppy/dump_utils.py
@@ -37,9 +37,9 @@ from opppy.progress import progress
 
 USE_THREADS = os.getenv("OPPPY_USE_THREADS", 'True').lower() in ('true', '1', 't')
 NTHREADS = int(os.getenv("OPPPY_N_THREADS", str(min(cpu_count(),4))))
-# Protect against multiprocessing fork issue on Windows
-if "windows" in platform.system().lower(): 
-    print("WARNING: DISABLING OPPPY MULTIPROCESSING THREADING ON WINDOWS SYSTEMS")
+# Protect against multiprocessing fork issue on Windows and Mac
+if "linux" not in platform.system().lower(): 
+    print("WARNING: DISABLING OPPPY MULTIPROCESSING THREADING ON WINDOWS/MAC SYSTEMS")
     USE_THREADS = False
     NTHREADS = 1
 

--- a/opppy/dump_utils.py
+++ b/opppy/dump_utils.py
@@ -30,12 +30,18 @@ import os
 import sys
 import pickle
 import math
+import platform
 from multiprocessing import Process, Manager, cpu_count
 
 from opppy.progress import progress
 
 USE_THREADS = os.getenv("OPPPY_USE_THREADS", 'True').lower() in ('true', '1', 't')
 NTHREADS = int(os.getenv("OPPPY_N_THREADS", str(min(cpu_count(),4))))
+# Protect against multiprocessing fork issue on Windows
+if "windows" in platform.system().lower(): 
+    print("WARNING: DISABLING OPPPY MULTIPROCESSING THREADING ON WINDOWS SYSTEMS")
+    USE_THREADS = False
+    NTHREADS = 1
 
 def point_value_1d(data, x_key, value_key, x_value, method='nearest'):
     '''

--- a/opppy/interactive_utils.py
+++ b/opppy/interactive_utils.py
@@ -611,7 +611,7 @@ class interactive_dump_parser:
         input_type_parser.add_argument('-cf','--case_file', dest='case_file', help='Case file to be pickled', nargs='?')
         pickle_parser.add_argument('-pf','--pickle_file', dest='pickle_name', help='Pickle file name to be created or appended to', required=True )
         pickle_parser.add_argument('-kw','--key_words', dest='key_words', help='Only extract the specified key_words', nargs='+', default=None )
-        pickle_parser.add_argument('-nt','--nthreads', dest='nthreads', help='Specify number of threads for dump parsing', nargs='?', default=0 )
+        pickle_parser.add_argument('-nt','--nthreads', dest='nthreads', help='Specify number of threads for dump parsing', nargs='?', type=int, default=0 )
         pickle_parser.set_defaults(func=self.pickle_dumps)
  
     def pickle_dumps(self, args):
@@ -665,6 +665,7 @@ class interactive_dump_parser:
         input_type_parser.add_argument('-pf','--pickle_files', dest='pickle_files', help='pickle files to be plotted (run1.p run2.p etc...)', nargs='+')
         input_type_parser.add_argument('-df','--dump_files', dest='dump_files', help='dump files to be parsed and plotted (output_file1.txt output_file2.txt etc...)', nargs='+', action='append')
         input_type_parser.add_argument('-cf','--case_files', dest='case_files', help='Case file to be ploted', nargs='+')
+        plot_parser.add_argument('-nt','--nthreads', dest='nthreads', help='Specify number of threads for dump parsing', nargs='?', type=int, default=0 )
         plot_parser.add_argument('-kw','--key_words', dest='key_words', help='Only extract the specified key_words', nargs='+', default=None )
         plot_parser.add_argument('-dk','--dimension_keys', dest='dimension_keys', help='keys used to extract the points (e.g. [x], [x,y], or [x,y,x]', nargs='+', required=True )
         plot_parser.add_argument('-p','--point', dest='point', help='point location to extract data (e.g. [1], [1,2], or [1,2,3]', nargs='+', required=True, type=float )
@@ -730,6 +731,7 @@ class interactive_dump_parser:
         input_type_parser.add_argument('-pf','--pickle_files', dest='pickle_files', help='pickle files to be plotted (run1.p run2.p etc...)', nargs='+')
         input_type_parser.add_argument('-cf','--case_files', dest='case_files', help='Case file to be ploted', nargs='+')
         input_type_parser.add_argument('-df','--dump_files', dest='dump_files', help='dump files to be parsed and plotted (output_file1.txt output_file2.txt etc...)', nargs='+', action='append')
+        plot_parser.add_argument('-nt','--nthreads', dest='nthreads', help='Specify number of threads for dump parsing', nargs='?', type=int, default=0 )
         plot_parser.add_argument('-kw','--key_words', dest='key_words', help='Only extract the specified key_words', nargs='+', default=None )
         plot_parser.add_argument('-dk','--dimension_keys', dest='dimension_keys', help='keys used to extract the points (e.g. [x], [x,y], or [x,y,x]', nargs='+', required=True )
         plot_parser.add_argument('-p0','--point0', dest='point0', help='beginning point location to extract data (e.g. [1], [1,2], or [1,2,3]', nargs='+', required=True, type=float )
@@ -788,6 +790,7 @@ class interactive_dump_parser:
         input_type_parser.add_argument('-pf','--pickle_file', dest='pickle_file', help='pickle file to be plotted', nargs='?')
         input_type_parser.add_argument('-cf','--case_file', dest='case_file', help='Case file to be ploted', nargs='?')
         input_type_parser.add_argument('-df','--dump_files', dest='dump_files', help='dump files to be parsed and plotted (output_file1.txt output_file2.txt etc...)', nargs='+')
+        plot_parser.add_argument('-nt','--nthreads', dest='nthreads', help='Specify number of threads for dump parsing', nargs='?', type=int, default=0 )
         plot_parser.add_argument('-kw','--key_words', dest='key_words', help='Only extract the specified key_words', nargs='+', default=None )
         plot_parser.add_argument('-dk','--dimension_keys', dest='dimension_keys', help='keys used to extract the points dimensions in the dictionary (e.g. [x,y], or [my_x,my_y,my_z]', nargs='+', required=True )
         plot_parser.add_argument('-zs','--z_slice_location', dest='z_slice_location', help='location along the z plane to slice the data', nargs='?', type=float, default=None)

--- a/opppy/interactive_utils.py
+++ b/opppy/interactive_utils.py
@@ -158,7 +158,7 @@ class interactive_output_parser:
           sys.exit(0)
     
         # append new dictionary data to the pickle file
-        append_output_dictionary(data, args.output_files, self.opppy_parser, args.append_date)
+        append_output_dictionary(data, args.output_files, self.opppy_parser, args.append_date, args.nthreads)
     
         pickle.dump(data,open(args.pickle_name,"wb"))
         print("Output Data Saved To: ", args.pickle_name)
@@ -169,6 +169,7 @@ class interactive_output_parser:
         pickle_parser.add_argument('-of','--output_files', dest='output_files', help='output files to generate/append the pickle file', nargs='+', required=True )
         pickle_parser.add_argument('-pf','--pickle_file', dest='pickle_name', help='Pickle file name to be created or appended to', required=True )
         pickle_parser.add_argument('-ad','--append_date', dest='append_date', help='Append the date and time to the output file name', nargs='?', type=bool, const=True, default=False)
+        pickle_parser.add_argument('-nt','--nthreads', dest='nthreads', help='Number of threads to use during parsing', nargs='?', type=int, default=0)
         pickle_parser.set_defaults(func=self.append_pickle)
  
 
@@ -180,6 +181,7 @@ class interactive_output_parser:
         input_type_parser = plot_parser.add_mutually_exclusive_group(required=True)
         input_type_parser.add_argument('-pf','--pickle_files', dest='pickle_files', help='pickle files to be plotted (run1.p run2.p etc...)', nargs='+' )
         input_type_parser.add_argument('-of','--output_files', dest='output_files', help='output files to be parsed and plotted (output_file1.txt output_file2.txt etc...)', nargs='+', action='append')
+        plot_parser.add_argument('-nt','--nthreads', dest='nthreads', help='Number of threads to use during parsing', nargs='?', type=int, default=0)
         self.dict_ploter = plot_dictionary()
         self.dict_ploter.setup_parser(plot_parser)
         plot_parser.set_defaults(func=self.plot_dictionary)
@@ -210,6 +212,7 @@ class interactive_output_parser:
         input_type_parser = plot_output_parser.add_mutually_exclusive_group(required=True)
         input_type_parser.add_argument('-pf','--pickle_files', dest='pickle_files', help='pickle files to be plotted (run1.p run2.p etc...)', nargs='+' )
         input_type_parser.add_argument('-of','--output_files', dest='output_files', help='output files to be parsed and plotted (output_file1.txt output_file2.txt etc...)', nargs='+', action='append')
+        plot_output_parser.add_argument('-nt','--nthreads', dest='nthreads', help='Number of threads to use during parsing', nargs='?', type=int, default=0)
         plot_output_parser.set_defaults(func=self.plot_output)
     
     def get_plot_option(self):
@@ -608,6 +611,7 @@ class interactive_dump_parser:
         input_type_parser.add_argument('-cf','--case_file', dest='case_file', help='Case file to be pickled', nargs='?')
         pickle_parser.add_argument('-pf','--pickle_file', dest='pickle_name', help='Pickle file name to be created or appended to', required=True )
         pickle_parser.add_argument('-kw','--key_words', dest='key_words', help='Only extract the specified key_words', nargs='+', default=None )
+        pickle_parser.add_argument('-nt','--nthreads', dest='nthreads', help='Specify number of threads for dump parsing', nargs='?', default=0 )
         pickle_parser.set_defaults(func=self.pickle_dumps)
  
     def pickle_dumps(self, args):
@@ -639,7 +643,7 @@ class interactive_dump_parser:
           sys.exit(0)
 
         if args.dump_files is not None:
-            append_dumps(dumps,args.dump_files,self.dump_parser,args.key_words)
+            append_dumps(dumps,args.dump_files,self.dump_parser,args.key_words,args.nthreads)
         else:
             append_case(dumps,args.case_file,self.dump_parser,args.key_words)
 
@@ -927,7 +931,7 @@ class interactive_tally_parser:
           sys.exit(0)
     
         # append new dictionary data to the pickle file
-        append_tally_dictionary(data, args.tally_files, self.opppy_parser, args.append_date)
+        append_tally_dictionary(data, args.tally_files, self.opppy_parser, args.append_date, args.nthreads)
     
         pickle.dump(data,open(args.pickle_name,"wb"))
         print("Output Data Saved To: ", args.pickle_name)
@@ -938,6 +942,7 @@ class interactive_tally_parser:
         pickle_parser.add_argument('-tf','--tally_files', dest='tally_files', help='output files to generate/append the pickle file', nargs='+', required=True )
         pickle_parser.add_argument('-pf','--pickle_file', dest='pickle_name', help='Pickle file name to be created or appended to', required=True )
         pickle_parser.add_argument('-ad','--append_date', dest='append_date', help='Append the date and time to the output file name', nargs='?', type=bool, const=True, default=False)
+        pickle_parser.add_argument('-nt','--nthreads', dest='nthreads', help='Number of threads to use during parsing', nargs='?', type=int, default=0)
         pickle_parser.set_defaults(func=self.append_pickle)
  
 
@@ -951,6 +956,7 @@ class interactive_tally_parser:
         input_type_parser.add_argument('-tf','--tally_files', dest='tally_files', help='tally files to be parsed and plotted (tally_file1.txt tally_file2.txt etc...)', nargs='+', action='append')
         plot_parser.add_argument('-sk','--series_key', dest='series_key', help='Series key string to access the data (i.e time or cycle)', nargs='?', required=True)
         plot_parser.add_argument('-sv','--series_value', dest='series_value', help='Series value to plot the data at (default is the last value of the series_key data)', nargs='?', type=float, default=None)
+        plot_parser.add_argument('-nt','--nthreads', dest='nthreads', help='Number of threads to use during parsing', nargs='?', type=int, default=0)
         self.dict_ploter = plot_dictionary()
         self.dict_ploter.setup_parser(plot_parser)
         plot_parser.set_defaults(func=self.plot_tally)
@@ -1001,6 +1007,7 @@ class interactive_tally_parser:
         input_type_parser = plot_parser.add_mutually_exclusive_group(required=True)
         input_type_parser.add_argument('-pf','--pickle_files', dest='pickle_files', help='pickle files to be plotted (run1.p run2.p etc...)', nargs='+' )
         input_type_parser.add_argument('-tf','--tally_files', dest='tally_files', help='tally files to be parsed and plotted (tally_file1.txt tally_file2.txt etc...)', nargs='+', action='append')
+        plot_parser.add_argument('-nt','--nthreads', dest='nthreads', help='Number of threads to use during parsing', nargs='?', type=int, default=0)
         
         plot_parser.set_defaults(func=self.plot_interactive_tally)
     

--- a/opppy/output.py
+++ b/opppy/output.py
@@ -28,6 +28,7 @@ import pickle
 import io
 import os
 import math
+import platform
 import numpy as np
 from multiprocessing import Process, Manager, cpu_count
 
@@ -36,6 +37,11 @@ from opppy.progress import *
 
 USE_THREADS = os.getenv("OPPPY_USE_THREADS", 'True').lower() in ('true', '1', 't')
 NTHREADS = int(os.getenv("OPPPY_N_THREADS", str(min(cpu_count(),4))))
+# Protect against multiprocessing fork issue on Windows
+if "windows" in platform.system().lower(): 
+    print("WARNING: DISABLING OPPPY MULTIPROCESSING THREADING ON WINDOWS SYSTEMS")
+    USE_THREADS = False
+    NTHREADS = 1
 
 def append_cycle_data(cycle_data, data, sort_key_string):
     '''

--- a/opppy/output.py
+++ b/opppy/output.py
@@ -37,9 +37,9 @@ from opppy.progress import *
 
 USE_THREADS = os.getenv("OPPPY_USE_THREADS", 'True').lower() in ('true', '1', 't')
 NTHREADS = int(os.getenv("OPPPY_N_THREADS", str(min(cpu_count(),4))))
-# Protect against multiprocessing fork issue on Windows
-if "windows" in platform.system().lower(): 
-    print("WARNING: DISABLING OPPPY MULTIPROCESSING THREADING ON WINDOWS SYSTEMS")
+# Protect against multiprocessing fork issue on Windows and Mac
+if "linux" not in platform.system().lower(): 
+    print("WARNING: DISABLING OPPPY MULTIPROCESSING THREADING ON WINDOWS/MAC SYSTEMS")
     USE_THREADS = False
     NTHREADS = 1
 

--- a/opppy/tally.py
+++ b/opppy/tally.py
@@ -37,9 +37,9 @@ from opppy.output import *
 
 USE_THREADS = os.getenv("OPPPY_USE_THREADS", 'True').lower() in ('true', '1', 't')
 NTHREADS = int(os.getenv("OPPPY_N_THREADS", str(min(cpu_count(),4))))
-# Protect against multiprocessing fork issue on Windows
-if "windows" in platform.system().lower(): 
-    print("WARNING: DISABLING OPPPY MULTIPROCESSING THREADING ON WINDOWS SYSTEMS")
+# Protect against multiprocessing fork issue on Windows and Mac
+if "linux" not in platform.system().lower(): 
+    print("WARNING: DISABLING OPPPY MULTIPROCESSING THREADING ON WINDOWS/MAC SYSTEMS")
     USE_THREADS = False
     NTHREADS = 1
 

--- a/opppy/tally.py
+++ b/opppy/tally.py
@@ -27,6 +27,7 @@ import pickle
 import io
 import os
 import math
+import platform
 import numpy as np
 from multiprocessing import Process, Manager, cpu_count
 
@@ -36,6 +37,11 @@ from opppy.output import *
 
 USE_THREADS = os.getenv("OPPPY_USE_THREADS", 'True').lower() in ('true', '1', 't')
 NTHREADS = int(os.getenv("OPPPY_N_THREADS", str(min(cpu_count(),4))))
+# Protect against multiprocessing fork issue on Windows
+if "windows" in platform.system().lower(): 
+    print("WARNING: DISABLING OPPPY MULTIPROCESSING THREADING ON WINDOWS SYSTEMS")
+    USE_THREADS = False
+    NTHREADS = 1
 
 def append_tally_data(cycle_data, data, sort_key_string):
     '''

--- a/opppy/tally.py
+++ b/opppy/tally.py
@@ -26,14 +26,16 @@ import sys
 import pickle
 import io
 import os
+import math
 import numpy as np
-from multiprocessing import Process, Manager
+from multiprocessing import Process, Manager, cpu_count
 
 from opppy.version import __version__
 from opppy.progress import *
 from opppy.output import *
 
 USE_THREADS = os.getenv("OPPPY_USE_THREADS", 'True').lower() in ('true', '1', 't')
+NTHREADS = int(os.getenv("OPPPY_N_THREADS", str(min(cpu_count(),4))))
 
 def append_tally_data(cycle_data, data, sort_key_string):
     '''
@@ -242,60 +244,50 @@ def append_tally_dictionary(data, output_files, opppy_parser, append_date=False)
     time = ''
     if append_date:
       time = time+'.'+datetime.datetime.now().strftime ("%Y%m%d%H%M%S")
-    count = 0
-    total = len(output_files) 
-    print('')
-    print("Number of files to be read: ", total)
-    data_list = []
-    if(USE_THREADS):
-      def thread_all(file_name, result_d):
-          thread_cycle_string_list = get_output_lines(file_name, opppy_parser.cycle_opening_string, opppy_parser.cycle_closing_string, opppy_parser.file_end_string)
-          thread_data=[]
-          for cycle_string in thread_cycle_string_list:
-              thread_data.append(extract_cycle_data(cycle_string, opppy_parser))
-          result_d[file_name] = thread_data
-
-      with Manager() as manager:
-            result_d = manager.dict()
-            threads = []
-            for file_name in output_files:
-                thread = Process(target=thread_all, args=(file_name, result_d,))
-                thread.start()
-                threads.append(thread)
-            for thread in threads:
-                thread.join()
-                count += 1
-                progress(count,total, 'of input files read')
-            for file_name in output_files:
-                data_list += result_d[file_name]
-    else:
-      cycle_string_list=[]
-      for file_name in output_files:
-        cycle_string_list+=get_output_lines(file_name, opppy_parser.cycle_opening_string, opppy_parser.cycle_closing_string, opppy_parser.file_end_string)
-        if 'appended_files' in data:
-            data['appended_files'].append(file_name.split('/')[-1]+time)
-        else:
-            data['appended_files'] = [file_name.split('/')[-1]+time]
-        count += 1
-        progress(count,total, 'of input files read')
-
-      total = len(cycle_string_list) 
-      count = 0
-      print('')
-      print("Number of cycles to be parsed: ", total)
-      for cycle_string in cycle_string_list:
-        data_list.append(extract_cycle_data(cycle_string, opppy_parser))
-        count += 1
-        progress(count,total, 'of cycles parsed')
-      print('')
-
     for file_name in output_files:
         if 'appended_files' in data:
             data['appended_files'].append(file_name.split('/')[-1]+time)
         else:
             data['appended_files'] = [file_name.split('/')[-1]+time]
-    for cycle_data in data_list:
-        data = append_tally_data(cycle_data,data,opppy_parser.sort_key_string)
+    count = 0
+    total = len(output_files) 
+    print('')
+    print("Number of files to be read: ", total)
+    if(USE_THREADS):
+      def thread_all(file_name, file_index, result_l):
+          thread_cycle_string_list = get_output_lines(file_name, opppy_parser.cycle_opening_string, opppy_parser.cycle_closing_string, opppy_parser.file_end_string)
+          thread_data=[]
+          for cycle_string in thread_cycle_string_list:
+              thread_data.append(extract_cycle_data(cycle_string, opppy_parser))
+          result_l[file_index] = thread_data
+          
+      print("Number of threads used for processing: ",NTHREADS)
+      for stride in range(math.ceil(float(total)/float(NTHREADS))):
+          files = output_files[NTHREADS*stride:min(NTHREADS*(stride+1),len(output_files))]
+          with Manager() as manager:
+                result_l = manager.list(range(len(files)))
+                threads = []
+                for file_index, file_name in enumerate(output_files):
+                    thread = Process(target=thread_all, args=(file_name, file_index, result_l,))
+                    thread.start()
+                    threads.append(thread)
+                for thread in threads:
+                    thread.join()
+                    count += 1
+                    progress(count,total, 'of input files read')
+                for file_data in result_l:
+                    for cycle_data in file_data:
+                       data = append_tally_data(cycle_data,data,opppy_parser.sort_key_string)
+                del result_l
+                del threads
+    else:
+      for file_name in output_files:
+        cycle_string_list = get_output_lines(file_name, opppy_parser.cycle_opening_string, opppy_parser.cycle_closing_string, opppy_parser.file_end_string)
+        for cycle_string in cycle_string_list:
+            cycle_data = extract_cycle_data(cycle_string, opppy_parser)
+            data = append_tally_data(cycle_data,data,opppy_parser.sort_key_string)
+        count += 1
+        progress(count,total, 'of input files read')
 
     print('')
     print('')

--- a/opppy/tally.py
+++ b/opppy/tally.py
@@ -273,7 +273,7 @@ def append_tally_dictionary(data, output_files, opppy_parser, append_date=False)
           with Manager() as manager:
                 result_l = manager.list(range(len(files)))
                 threads = []
-                for file_index, file_name in enumerate(output_files):
+                for file_index, file_name in enumerate(files):
                     thread = Process(target=thread_all, args=(file_name, file_index, result_l,))
                     thread.start()
                     threads.append(thread)

--- a/tests/test_dump_utils.py
+++ b/tests/test_dump_utils.py
@@ -55,7 +55,7 @@ class test_opppy_dump_utils(unittest.TestCase):
         assert(data.keys()==gold_data.keys())
         for k, v in gold_data.items():
             try:
-                assert((data[k]==v).all())
+                np.testing.assert_allclose(data[k],v)
             except:
                 assert(data[k]==v)
 
@@ -76,7 +76,7 @@ class test_opppy_dump_utils(unittest.TestCase):
         assert(sub_data.keys()==gold_data.keys())
         for k, v in gold_data.items():
             try:
-                assert((sub_data[k]==v).all())
+                np.testing.assert_allclose(sub_data[k],v)
             except:
                 assert(sub_data[k]==v)
 
@@ -129,7 +129,7 @@ class test_opppy_dump_utils(unittest.TestCase):
             assert(data[dump_name].keys()==dump_dic.keys())
             for k, v in dump_dic.items():
                 try:
-                    assert((data[dump_name][k]==v).all())
+                    np.testing.assert_allclose(data[dump_name][k],v)
                 except:
                     assert(data[dump_name][k]==v)
 
@@ -151,7 +151,7 @@ class test_opppy_dump_utils(unittest.TestCase):
             assert(data2[dump_name].keys()==dump_dic.keys())
             for k, v in dump_dic.items():
                 try:
-                    assert((data2[dump_name][k]==v).all())
+                    np.testing.assert_allclose(data2[dump_name][k],v)
                 except:
                     assert(data2[dump_name][k]==v)
 
@@ -178,7 +178,7 @@ class test_opppy_dump_utils(unittest.TestCase):
             assert(sub_data[dump_name].keys()==dump_dic.keys())
             for k, v in dump_dic.items():
                 try:
-                    assert((sub_data[dump_name][k]==v).all())
+                    np.testing.assert_allclose(sub_data[dump_name][k],v)
                 except:
                     assert(sub_data[dump_name][k]==v)
 
@@ -263,7 +263,7 @@ class test_opppy_dump_utils(unittest.TestCase):
         gold_data = pickle.load(goldfile)
         goldfile.close()
         for k, v in gold_data.items():
-            assert((tracer_data[k]==v).all())
+            np.testing.assert_allclose(tracer_data[k],v)
 
 
     
@@ -315,7 +315,7 @@ class test_opppy_dump_utils(unittest.TestCase):
         goldfile.close()
         for key, gold_dic in  gold_data.items():
             for k, v in gold_dic.items():
-                assert((check_data[key][k]==v).all())
+                np.testing.assert_allclose(check_data[key][k],v)
 
 
 
@@ -364,7 +364,7 @@ class test_opppy_dump_utils(unittest.TestCase):
         gold_data = pickle.load(goldfile)
         goldfile.close()
         for k, v in  gold_data.items():
-            assert((check_data[k]==v).all())
+            np.testing.assert_allclose(check_data[k],v)
 
 
     def test_2D_slice_series(self):
@@ -400,7 +400,7 @@ class test_opppy_dump_utils(unittest.TestCase):
         gold_data = pickle.load(goldfile)
         goldfile.close()
         for k, v in  gold_data.items():
-            assert((check_data[k]==v).all())
+            np.testing.assert_allclose(check_data[k],v)
 
 
     def test_data_2_line(self):
@@ -446,7 +446,7 @@ class test_opppy_dump_utils(unittest.TestCase):
         gold_data = pickle.load(goldfile)
         goldfile.close()
         for k, v in  gold_data.items():
-            assert((check_data[k]==v).all())
+            np.testing.assert_allclose(check_data[k],v)
 
        
 
@@ -500,6 +500,6 @@ class test_opppy_dump_utils(unittest.TestCase):
         gold_data = pickle.load(goldfile)
         goldfile.close()
         for k, v in  gold_data.items():
-            assert((check_data[k]==v).all())
+            np.testing.assert_allclose(check_data[k],v)
 
 

--- a/tests/test_dump_utils.py
+++ b/tests/test_dump_utils.py
@@ -155,6 +155,30 @@ class test_opppy_dump_utils(unittest.TestCase):
                 except:
                     assert(data2[dump_name][k]==v)
 
+        # TEST WITH THREADS
+        # initialize a new data dictionary
+        data3 = {}
+        data3['version'] = __version__
+      
+      
+        # Append the thrid output file
+        filenames = [dir_path+"example_dump.txt",dir_path+"example_dump2.txt",dir_path+"example_dump3.txt"]
+        # Build initial pickle
+        append_dumps(data3, filenames, dump_parser, nthreads=-1)
+     
+        print(data3)
+        # Don't check the version for a match
+        data3.pop('version')
+        assert(data3.keys()==gold_data.keys())
+        for dump_name, dump_dic in gold_data.items():
+            assert(data3[dump_name].keys()==dump_dic.keys())
+            for k, v in dump_dic.items():
+                try:
+                    np.testing.assert_allclose(data3[dump_name][k],v)
+                except:
+                    assert(data3[dump_name][k]==v)
+
+
         # extract subset of dump data
         sub_data = {}
         sub_data['version'] = __version__
@@ -181,6 +205,25 @@ class test_opppy_dump_utils(unittest.TestCase):
                     np.testing.assert_allclose(sub_data[dump_name][k],v)
                 except:
                     assert(sub_data[dump_name][k]==v)
+
+        # TEST WITH THREADS
+        # extract subset of dump data
+        sub_data2 = {}
+        sub_data2['version'] = __version__
+        filenames = [dir_path+"example_dump.txt",dir_path+"example_dump2.txt",dir_path+"example_dump3.txt"]
+        # Build initial pickle
+        append_dumps(sub_data2, filenames, dump_parser, ['time','density'], nthreads=-1)
+     
+        sub_data2.pop('version')
+        assert(sub_data2.keys()==gold_data.keys())
+        for dump_name, dump_dic in gold_data.items():
+            assert(sub_data2[dump_name].keys()==dump_dic.keys())
+            for k, v in dump_dic.items():
+                try:
+                    np.testing.assert_allclose(sub_data2[dump_name][k],v)
+                except:
+                    assert(sub_data2[dump_name][k]==v)
+
 
 
     def test_point_value(self):

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -44,10 +44,12 @@ class test_interactive_utils(unittest.TestCase):
         assert(os.system("python my_interactive_parser.py dump line -h")==0)
 
     def test_pickle_output(self):
-        # This uses glob to pickle all the output data
-        assert(os.system("python my_interactive_parser.py output pickle -pf interactive.p -of "+dir_path+"output_example*.txt")==0)
+        # This uses glob to pickle all the output data using all threads
+        assert(os.system("python my_interactive_parser.py output pickle -nt -1 -pf interactive.p -of "+dir_path+"output_example*.txt")==0)
+        # This uses glob to pickle all the output data using 2 threads
+        assert(os.system("python my_interactive_parser.py output pickle -nt 2 -pf interactive.p -of "+dir_path+"output_example*.txt")==0)
         # Test no threads
-        assert(os.system("OPPPY_USE_THREADS=False python my_interactive_parser.py output pickle -pf interactive.p -of "+dir_path+"output_example*.txt")==0)
+        assert(os.system("python my_interactive_parser.py output pickle -pf interactive.p -of "+dir_path+"output_example*.txt")==0)
 
     def test_plot_pickle(self):
         # This uses glob to pickle all the output data
@@ -56,6 +58,8 @@ class test_interactive_utils(unittest.TestCase):
         assert(os.system("python my_interactive_parser.py output iplot -pf interactive.p < "+dir_path+"interactive_input.txt")==0)
         # parse and plot the output data files
         assert(os.system("python my_interactive_parser.py output iplot -of "+dir_path+"output_example*.txt < "+dir_path+"interactive_input.txt")==0)
+        # parse and plot the output data files with threads
+        assert(os.system("python my_interactive_parser.py output iplot -nt -1 -of "+dir_path+"output_example*.txt < "+dir_path+"interactive_input.txt")==0)
 
     def test_plot_dictionary(self):
         # This uses glob to pickle all the output data
@@ -64,12 +68,16 @@ class test_interactive_utils(unittest.TestCase):
         assert(os.system("python my_interactive_parser.py output plot -pf interactive.p -dn density -x time -y mat1 -sa density_mat1.png -hp")==0)
         # parse and plot the output data files
         assert(os.system("python my_interactive_parser.py output plot -of "+dir_path+"output_example*.txt -dn density -x time -y mat1 -sa density_mat1_pp.png -hp")==0)
+        # parse and plot the output data files with threads 
+        assert(os.system("python my_interactive_parser.py output plot -nt -1 -of "+dir_path+"output_example*.txt -dn density -x time -y mat1 -sa density_mat1_pp.png -hp")==0)
 
     def test_pickle_dumps(self):
-        # This uses glob to pickle all the dump data
-        assert(os.system("python my_interactive_parser.py dump pickle -pf interactive_dump.p -df "+dir_path+"example_dump*.txt")==0)
+        # This uses glob to pickle all the dump data with all threads
+        assert(os.system("python my_interactive_parser.py dump pickle -nt -1 -pf interactive_dump.p -df "+dir_path+"example_dump*.txt")==0)
+        # This uses glob to pickle all the dump data with 2 threads
+        assert(os.system("python my_interactive_parser.py dump pickle -nt 2 -pf interactive_dump.p -df "+dir_path+"example_dump*.txt")==0)
         # Test serial parsing
-        assert(os.system("OPPPY_USE_THREADS=False python my_interactive_parser.py dump pickle -pf interactive_dump.p -df "+dir_path+"example_dump*.txt")==0)
+        assert(os.system("python my_interactive_parser.py dump pickle -pf interactive_dump.p -df "+dir_path+"example_dump*.txt")==0)
 
     def test_plot_dump(self):
         # This uses glob to pickle all the dump data
@@ -106,6 +114,9 @@ class test_interactive_utils(unittest.TestCase):
         # Parse and plot a point series
         assert(os.system("python my_interactive_parser.py dump point -df "+dir_path+"example_dump*.txt -df "+dir_path+"example_dump*.txt -dk x -p 5 -s time -d temperature -sy 10.0 -sy 1.0")==0)
 
+        # Parse and plot a point series with threads
+        assert(os.system("python my_interactive_parser.py dump point -nt -1 -df "+dir_path+"example_dump*.txt -df "+dir_path+"example_dump*.txt -dk x -p 5 -s time -d temperature -sy 10.0 -sy 1.0")==0)
+
         # test individual scale x
         assert(os.system("python my_interactive_parser.py dump point -df "+dir_path+"example_dump*.txt -df "+dir_path+"example_dump*.txt -dk x -p 5 -s time -d temperature -sx 10.0 -sx 1.0")==0)
 
@@ -128,10 +139,12 @@ class test_interactive_utils(unittest.TestCase):
         assert(os.system("python my_interactive_parser.py dump contour -pf interactive_dump.p -dk z y x -zs 5 -s time -d temperature -ls")==0)
 
     def test_pickle_tally(self):
-        # This uses glob to pickle all the output data
-        assert(os.system("python my_interactive_parser.py tally pickle -pf interactive_tally.p -tf "+dir_path+"example_tally*.txt")==0)
+        # This uses glob to pickle all the output data with threads
+        assert(os.system("python my_interactive_parser.py tally pickle -nt -1 -pf interactive_tally.p -tf "+dir_path+"example_tally*.txt")==0)
+        # This uses glob to pickle all the output data with 2 threads
+        assert(os.system("python my_interactive_parser.py tally pickle -nt 2 -pf interactive_tally.p -tf "+dir_path+"example_tally*.txt")==0)
         # Test Serial parsing
-        assert(os.system("OPPPY_USE_THREADS=False python my_interactive_parser.py tally pickle -pf interactive_tally.p -tf "+dir_path+"example_tally*.txt")==0)
+        assert(os.system("python my_interactive_parser.py tally pickle -pf interactive_tally.p -tf "+dir_path+"example_tally*.txt")==0)
 
     def test_plot_tally(self):
         # This uses glob to pickle all the output data
@@ -140,8 +153,12 @@ class test_interactive_utils(unittest.TestCase):
         assert(os.system("python my_interactive_parser.py tally iplot -pf interactive_tally.p < "+dir_path+"interactive_tally_input.txt")==0)
         # parse and plot the output data files
         assert(os.system("python my_interactive_parser.py tally iplot -tf "+dir_path+"example_tally*.txt < "+dir_path+"interactive_tally_input.txt")==0)
+        # parse and plot the output data files with threads
+        assert(os.system("python my_interactive_parser.py tally iplot -nt -1 -tf "+dir_path+"example_tally*.txt < "+dir_path+"interactive_tally_input.txt")==0)
         # parse and plot the output data files
         assert(os.system("python my_interactive_parser.py tally plot -tf "+dir_path+"example_tally*.txt -sk cycle -dn cool_counts -x bins -xlab 'bin [#]'  -y odd_counts  -ylab 'Counts [#]'")==0)
         assert(os.system("python my_interactive_parser.py tally plot -pf interactive_tally.p -sk time -sv 5.0 -dn cool_counts -x bins -xlab 'bin [#]'  -y even_counts  -ylab 'Counts [#]'")==0)
+        # parse and plot the output data files with threads
+        assert(os.system("python my_interactive_parser.py tally plot -nt -1 -tf "+dir_path+"example_tally*.txt -sk cycle -dn cool_counts -x bins -xlab 'bin [#]'  -y odd_counts  -ylab 'Counts [#]'")==0)
         # test scaling and log axis
         assert(os.system("python my_interactive_parser.py tally plot -tf "+dir_path+"example_tally*.txt -tf "+dir_path+"example_tally*.txt -sk cycle -dn cool_counts -x bins -xlab 'bin [#]'  -y odd_counts  -ylab 'Counts  [#]' -lx -ly -sx 10 -sx 1e-3 -sy 10 -sy 1e-3 -xl 0.00001 1000 -yl 0.00001 10000")==0)

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -142,3 +142,18 @@ class test_opppy_outputs(unittest.TestCase):
     data2.pop('version')
     assert(data2==gold_data)
 
+    # initialize a new data dictionary
+    data3 = {}
+    data3['version'] = __version__
+  
+  
+    # Append the thrid output file
+    output_files = [dir_path+"output_example1.txt",dir_path+"output_example2.txt",dir_path+"output_example3.txt"]
+    # Build initial pickle
+    append_output_dictionary(data3, output_files, opppy_parser, nthreads=-1)
+
+    print(data3)
+    # Don't check the version for a match
+    data3.pop('version')
+    assert(data3==gold_data)
+

--- a/tests/test_tally.py
+++ b/tests/test_tally.py
@@ -115,3 +115,20 @@ class test_opppy_tally(unittest.TestCase):
     data2.pop('version')
     for dic, gold_dic in zip(data2,gold_data):
         assert(dic==gold_dic)
+
+    # initialize a new data dictionary
+    data3 = {}
+    data3['version'] = __version__
+  
+  
+    # WITH THREADS
+    # Append the thrid tally file
+    tally_files = [dir_path+"example_tally1.txt",dir_path+"example_tally2.txt",dir_path+"example_tally3.txt"]
+    # Build initial pickle
+    append_tally_dictionary(data3, tally_files, opppy_parser, nthreads=-1)
+
+    print(data3)
+    # Don't check the version for a match
+    data3.pop('version')
+    for dic, gold_dic in zip(data3,gold_data):
+        assert(dic==gold_dic)


### PR DESCRIPTION
* Set a threading stride for parallel file parsing to reduce memory (running to many threads can overwhelm the memory footprint)
* Add OPPPY_N_THREADS (default=4) environment variable
* Cleanup memory high water mark for serial tally and output data processing
*  Add a serial testing using the OPPPY_USE_THREADS enviroment variable. 