### PR TITLE
Enable time dependent tally data plotting

### DIFF
--- a/opppy/interactive_utils.py
+++ b/opppy/interactive_utils.py
@@ -971,27 +971,50 @@ class interactive_tally_parser:
                 raw_dictionary_names.append(pickle_file_name.split('/')[-1].split('.p')[0])
                 raw_dictionary_data.append(pickle.load(open(pickle_file_name,'rb')))
 
+        y_index = []
+        y_names = []
+        time_dependent = False
+        if args.x_value_name == args.series_key:
+            time_dependent = True
+            for yname in args.y_value_names:
+                if("." in yname):
+                    y_index.append(int(yname.split(".")[-1]))
+                    y_names.append(yname.split(".")[0])
+
         # build up plotting dictionary list and names
         dictionary_data = []
         dictionary_names = []
         for dictionary, name in zip(raw_dictionary_data,raw_dictionary_names):
             found = False
             times = dictionary[args.series_key]
-            if args.series_value is not None:
-                for index, time in enumerate(times):
-                    if(time >= args.series_value):
-                        found = True
-                        tally = dictionary['tally_cycle_data'][index]
-                        dictionary_data.append(tally)  
-                        dictionary_names.append(name + ' ' + args.series_key + " = " + str(time))
-                        break
-                    
-            if not found:
-                tally = dictionary['tally_cycle_data'][-1]
-                dictionary_data.append(tally)  
-                dictionary_names.append(name + ' ' + args.series_key + " = " + str(times[-1]))
-
-
+            if(time_dependent):
+                my_dictionary = {}
+                my_dictionary[args.series_key] = times
+                for index, yname in enumerate(args.y_value_names):
+                    if(len(y_index)>0):
+                       my_dictionary[yname] = [
+                               tally[args.dictionary_name][y_names[index]][y_index[index]] for tally in
+                                                              dictionary['tally_cycle_data']]
+                    else:
+                        my_dictionary[yname] = [ tally[yname] for tally in
+                                                              dictionary['tally_cycle_data']]
+                
+                dictionary_data.append({args.dictionary_name: my_dictionary})
+                dictionary_names.append(name)
+            else:
+                if args.series_value is not None:
+                    for index, time in enumerate(times):
+                        if(time >= args.series_value):
+                            found = True
+                            tally = dictionary['tally_cycle_data'][index]
+                            dictionary_data.append(tally)  
+                            dictionary_names.append(name + ' ' + args.series_key + " = " + str(time))
+                            break
+                        
+                if not found:
+                    tally = dictionary['tally_cycle_data'][-1]
+                    dictionary_data.append(tally)  
+                    dictionary_names.append(name + ' ' + args.series_key + " = " + str(times[-1]))
 
         # plot dictionaries based on input arguments
         self.dict_ploter.plot_dict(args,dictionary_data,dictionary_names)
@@ -1098,7 +1121,18 @@ class interactive_tally_parser:
             plot_num = get_option_num(counter)-1
             label = labels[plot_num][0]
             plot_args = labels[plot_num][-1]
-            plot_args.series_value = get_option_series_value(plot_args.series_key,raw_dictionary_data[0][plot_args.series_key])
+            plot_args.series_value = ( get_option_series_value(plot_args.series_key,raw_dictionary_data[0][plot_args.series_key]) 
+                                      if plot_args.series_key!=plot_args.x_value_name else None)
+
+            y_index = []
+            y_names = []
+            time_dependent = False
+            if plot_args.x_value_name == plot_args.series_key:
+                time_dependent = True
+                for yname in plot_args.y_value_names:
+                    if("." in yname):
+                        y_index.append(int(yname.split(".")[-1]))
+                        y_names.append(yname.split(".")[0])
 
             # build up plotting dictionary list and names
             dictionary_data = []
@@ -1106,20 +1140,34 @@ class interactive_tally_parser:
             for dictionary, name in zip(raw_dictionary_data,raw_dictionary_names):
                 found = False
                 times = dictionary[plot_args.series_key]
-                if plot_args.series_value is not None:
-                    for index, time in enumerate(times):
-                        if(time >= plot_args.series_value):
-                            found = True
-                            tally = dictionary['tally_cycle_data'][index]
-                            dictionary_data.append(tally)  
-                            dictionary_names.append(name + ' ' + plot_args.series_key + " = " + str(time))
-                            break
-                        
-                if not found:
-                    tally = dictionary['tally_cycle_data'][-1]
-                    dictionary_data.append(tally)  
-                    dictionary_names.append(name + ' ' + plot_args.series_key + " = " + str(times[-1]))
-
+                if(time_dependent):
+                    my_dictionary = {}
+                    my_dictionary[plot_args.series_key] = times
+                    for index, yname in enumerate(plot_args.y_value_names):
+                        if(len(y_index)>0):
+                           my_dictionary[yname] = [
+                                   tally[plot_args.dictionary_name][y_names[index]][y_index[index]] for tally in
+                                                                  dictionary['tally_cycle_data']]
+                        else:
+                            my_dictionary[yname] = [ tally[yname] for tally in
+                                                                  dictionary['tally_cycle_data']]
+                    
+                    dictionary_data.append({plot_args.dictionary_name: my_dictionary})
+                    dictionary_names.append(name)
+                else:
+                    if plot_args.series_value is not None:
+                        for index, time in enumerate(times):
+                            if(time >= plot_args.series_value):
+                                found = True
+                                tally = dictionary['tally_cycle_data'][index]
+                                dictionary_data.append(tally)  
+                                dictionary_names.append(name + ' ' + plot_args.series_key + " = " + str(time))
+                                break
+                            
+                    if not found:
+                        tally = dictionary['tally_cycle_data'][-1]
+                        dictionary_data.append(tally)  
+                        dictionary_names.append(name + ' ' + plot_args.series_key + " = " + str(times[-1]))
 
             if plot_args.y_value_names[0] == "select_key":    
                 keys = list(dictionary_data[-1][plot_args.dictionary_name].keys())

--- a/opppy/plot_dictionary.py
+++ b/opppy/plot_dictionary.py
@@ -55,6 +55,8 @@ class plot_dictionary():
             dictonary the dictonary to search for the x and y data value names
         '''
         try:
+            if(args.series_key==args.x_value_name):
+                return True
             data = dictionary[args.dictionary_name]
             x = data[args.x_value_name]
             if not (args.y_value_names[0] == "select_key"):

--- a/opppy/plot_dictionary.py
+++ b/opppy/plot_dictionary.py
@@ -54,9 +54,8 @@ class plot_dictionary():
             args parsed dictionary plotting arguments 
             dictonary the dictonary to search for the x and y data value names
         '''
+        
         try:
-            if(args.series_key==args.x_value_name):
-                return True
             data = dictionary[args.dictionary_name]
             x = data[args.x_value_name]
             if not (args.y_value_names[0] == "select_key"):
@@ -64,7 +63,13 @@ class plot_dictionary():
                     y = data[yname]
             return True
         except:
-            return False
+            try:
+                if(args.series_key==args.x_value_name):
+                    return True
+                else:
+                    return False
+            except:
+                return False
  
     def setup_parser(self, parser):
         '''

--- a/tests/my_test_opppy_tally_parser.py
+++ b/tests/my_test_opppy_tally_parser.py
@@ -47,7 +47,7 @@ class my_test_opppy_tally_parser():
                         data_dict["n_"+key] = sum(counts[key])
 
                     # store problem data
-                    if key is 'bins':
+                    if key == 'bins':
                         problem_data_dict[key] = array(str_vector_to_float_vector(line.strip('\n').split(' ')[1:]))
                         problem_data_dict['number_of_bins'] = len(problem_data_dict[key])
        

--- a/tests/test_interactive.py
+++ b/tests/test_interactive.py
@@ -142,6 +142,7 @@ class test_interactive_utils(unittest.TestCase):
         assert(os.system("python my_interactive_parser.py tally iplot -tf "+dir_path+"example_tally*.txt < "+dir_path+"interactive_tally_input.txt")==0)
         # parse and plot the output data files
         assert(os.system("python my_interactive_parser.py tally plot -tf "+dir_path+"example_tally*.txt -sk cycle -dn cool_counts -x bins -xlab 'bin [#]'  -y odd_counts  -ylab 'Counts [#]'")==0)
+        assert(os.system("python my_interactive_parser.py tally plot -tf "+dir_path+"example_tally*.txt -sk cycle -dn cool_counts -x cycle -xlab 'Cycle [#]'  -y odd_counts.0  -ylab 'Counts[0] [#]'")==0)
         assert(os.system("python my_interactive_parser.py tally plot -pf interactive_tally.p -sk time -sv 5.0 -dn cool_counts -x bins -xlab 'bin [#]'  -y even_counts  -ylab 'Counts [#]'")==0)
         # test scaling and log axis
         assert(os.system("python my_interactive_parser.py tally plot -tf "+dir_path+"example_tally*.txt -tf "+dir_path+"example_tally*.txt -sk cycle -dn cool_counts -x bins -xlab 'bin [#]'  -y odd_counts  -ylab 'Counts  [#]' -lx -ly -sx 10 -sx 1e-3 -sy 10 -sy 1e-3 -xl 0.00001 1000 -yl 0.00001 10000")==0)


### PR DESCRIPTION
Plotting tally data was previously limited to sub dictionaries. However, often times we wish to see how a single value in the tally structure changes as a function of time. This enables us to plot the time dependent data. The time dependent plot is assumed when the series_key and x_value_name match.